### PR TITLE
Use Problem.send to emit response so that status code is set

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,12 +1,9 @@
 import Problem from './index'
 
-const CONTENT_TYPE = 'application/problem+json'
-
 export default function Middleware (space = null) {
   return (err, req, res, next) => {
     if (err instanceof Problem) {
-      res.set('Content-Type', CONTENT_TYPE)
-      res.send(JSON.stringify(err, null, space))
+      err.send(res, space)
     } else {
       return next()
     }

--- a/test/middlewear.js
+++ b/test/middlewear.js
@@ -5,17 +5,18 @@ import { test } from 'tap'
 const CONTENT_TYPE = 'application/problem+json'
 
 test('Express Middleware', (assert) => {
-  assert.plan(4)
+  assert.plan(5)
 
   let problem = new Problem(404)
 
   let req = {}
   let res = {
-    set (name, value) {
-      assert.equal(value, CONTENT_TYPE, 'set correct Content-Type')
+    writeHead (status, headers) {
+      assert.equal(status, '404', 'set correct status code')
+      assert.same(headers, { 'Content-Type': CONTENT_TYPE }, 'set correct HTTP headers')
     },
 
-    send (body) {
+    end (body) {
       assert.equal(body, JSON.stringify(problem), 'serialized JSON response')
     }
   }
@@ -23,9 +24,9 @@ test('Express Middleware', (assert) => {
   Middleware()(problem, req, res)
 
   res = {
-    set (name, value) {},
+    writeHead (status, headers) {},
 
-    send (body) {
+    end (body) {
       assert.equal(body, JSON.stringify(problem, null, 2), 'spaced + serialized JSON response')
     }
   }


### PR DESCRIPTION
I just started using your library today and in a test were I wanted to check that I get a proper 404 response back, I noticed that the response uses the status code `200` whereas the body contained the correct payload.

Just went ahead and reused the `Problem.send` method in the middleware.